### PR TITLE
[bar] Hide the share bar when Bluetooth is disabled

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -134,7 +134,7 @@ AC_ARG_WITH(cajadir,
 	    [ac_with_cajadir=""])
 
 PKG_CHECK_MODULES(EXTENSION,
-		   libcaja-extension)
+		   libcaja-extension mate-bluetooth-1.0)
 if test "${ac_with_cajadir}" = ""; then
 	ac_with_cajadir=`pkg-config --variable=extensiondir libcaja-extension`
 fi


### PR DESCRIPTION
A bar always appears on top of XDG_DOWNLOAD_DIR view in caja even
without a bluetooth adapter present or enabled.
This patch uses BluetoothClient's "default-adapter" property to
detect whether we have an enabled bluetooth adapter, and only if
so, show the bar telling the user they can receive files over
bluetooth into this folder.
Patch adapted for mate-user-share from Baptiste Mille-Mathias'
patch against gnome-user-share, for the same issue.
Origin: https://bugzilla.gnome.org/show_bug.cgi?id=613584
