### PR TITLE
renamed extension lib

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -68,16 +68,16 @@ mate_file_share_properties_LDADD = \
 	$(USER_SHARE_CONFIG_LIBS)
 
 caja_extensiondir = $(CAJADIR)
-caja_extension_LTLIBRARIES = libcaja-share-extension.la
+caja_extension_LTLIBRARIES = libcaja-user-share.la
 
-libcaja_share_extension_la_SOURCES =	\
+libcaja_user_share_la_SOURCES =	\
 	caja-share-bar.c			\
 	caja-share-bar.h			\
 	share-extension.c			\
 	$(NULL)
 
-libcaja_share_extension_la_LIBADD = libuser-share-common.la $(EXTENSION_LIBS)
-libcaja_share_extension_la_LDFLAGS = -avoid-version -module -no-undefined
+libcaja_user_share_la_LIBADD = libuser-share-common.la $(EXTENSION_LIBS)
+libcaja_user_share_la_LDFLAGS = -avoid-version -module -no-undefined
 
 EXTRA_DIST = marshal.list
 


### PR DESCRIPTION
this has a few benefits:
- the new name looks more consistent among other caja extension libs
- less chance to confuse it with caja-share extension
- proper extension description and about dialog due to the new name
  corresponding to .caja-extension file name (see https://github.com/mate-desktop/mate-user-share/issues/26)