### PR TITLE
Change url project's website

### DIFF
--- a/data/libcaja-user-share.caja-extension.in.in
+++ b/data/libcaja-user-share.caja-extension.in.in
@@ -4,4 +4,4 @@ _Name=User Share
 _Description=Integrates with user-share
 Copyright=Copyright (C) 2005 William Jon McCann <mccann@jhu.edu>
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.